### PR TITLE
Include pam_keyinit.so in pam configuration

### DIFF
--- a/pam-backend/gnomesu-pam
+++ b/pam-backend/gnomesu-pam
@@ -5,4 +5,5 @@ auth       required     pam_stack.so service=system-auth
 session    required     pam_permit.so
 session    required     pam_xauth.so
 session    optional     pam_timestamp.so
+session    optional     pam_keyinit.so force revoke
 account    required     pam_permit.so


### PR DESCRIPTION
To support kernel keyrings used by systemd

Please see https://bugzilla.opensuse.org/show_bug.cgi?id=1144048