### PR TITLE
Add support for pam_env module

### DIFF
--- a/pam-backend/pam.c
+++ b/pam-backend/pam.c
@@ -229,6 +229,7 @@ main (int argc, char *argv[])
 	struct passwd *pw;
 	pam_handle_t *pamh = NULL;
 	int retval, i;
+	char **env;
 
 	pw = init (argc, argv);
 
@@ -357,6 +358,12 @@ main (int argc, char *argv[])
 		}
 
 		modify_environment (pw);
+
+		env = pam_getenvlist(pamh);
+		while (env && *env) {
+			xputenv(*env);
+			env++;
+		}
 
 		pid = fork ();
 		switch (pid)


### PR DESCRIPTION
This solves https://bugzilla.opensuse.org/show_bug.cgi?id=1254672 where gnomesu ignores pam_env configuration

see also https://github.com/openSUSE/libgnomesu/issues/8